### PR TITLE
Fixed a typo in column names (?)

### DIFF
--- a/BayesianTools/R/classMcmcSampler.R
+++ b/BayesianTools/R/classMcmcSampler.R
@@ -58,7 +58,7 @@ getSample.mcmcSampler <- function(sampler, parametersOnly = T, coda = F, start =
         if(!is.null(sampler$setup$names)) colnames(temp) = sampler$setup$names
       }
       else {
-        if(!is.null(sampler$setup$names)) colnames(temp) = c(sampler$setup$names, "Lposterior", "Llikelihod", "Lprior")
+        if(!is.null(sampler$setup$names)) colnames(temp) = c(sampler$setup$names, "Lposterior", "Llikelihood", "Lprior")
       }
       
       ########################

--- a/BayesianTools/R/classSmcSampler.R
+++ b/BayesianTools/R/classSmcSampler.R
@@ -10,7 +10,7 @@ getSample.smcSampler <- function(sampler, parametersOnly = T, coda = F, start = 
   }
   else {
     out = cbind(sampler$particles[start:end,] , sampler$posterior[start:end,] )
-    if(!is.null(sampler$setup$names)) colnames(out) = c(sampler$setup$names, "Lposterior", "Llikelihod", "Lprior")
+    if(!is.null(sampler$setup$names)) colnames(out) = c(sampler$setup$names, "Lposterior", "Llikelihood", "Lprior")
   }
   
   ########################


### PR DESCRIPTION
Hi, thanks for the great package ! (I'm using it daily)

I just got bit this morning by what may be a typo in the column names returned by getSample(). It's not much, but it means that the names in the table returned by getSample() can change depending on the settings used in runMCMC() (so columns in that table cannot be extracted reliably further down in  the code). 

Hope this helps, thanks again !

Alexandre
